### PR TITLE
Return an error exit code when failing

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -707,5 +707,5 @@ int main_loop(void) {
 	sigprocmask(SIG_SETMASK, &omask, NULL);
 #endif
 
-	return 0;
+	return 1;
 }


### PR DESCRIPTION
The main_loop runs forever, unless there are 10 consecutive read errors ("Too many errors from %s, exiting!"). In this case, main_loop should return an error exit code instead of a success error code.